### PR TITLE
修改提示语的调用

### DIFF
--- a/vue/api-examples/src/utils/utils.js
+++ b/vue/api-examples/src/utils/utils.js
@@ -13,7 +13,7 @@ export const getDefaultLanguage = () => {
 
 export const showJoinedMessage = (options) => {
   if (options.token) {
-    message.success("Congratulations! Joined room successfully.")
+    ElMessage.success("Congratulations! Joined room successfully.")
   } else {
     const href = window.location.href.split('?')[0]
     const finHref = `${href}?appId=${options.appId}&channel=${options.channel}`


### PR DESCRIPTION
Vue的demo中，utils.js中16行展示提示语的时候，调用的是message，message在文件中并未定义。
应使用文件首行从element-plus中引入的ElMessage进行调用。